### PR TITLE
Use explicit time zone

### DIFF
--- a/handlers/execute-db-queries.js
+++ b/handlers/execute-db-queries.js
@@ -38,7 +38,8 @@ export const executeGetTags = async () => {
 
 export const executeGetEventsToDisplay = async (date) => {
     try {
-        const [ [ events ] ] = await pool.query('CALL GetEventsToDisplay_V2(?)', [ date ]);
+        const dateToDB = date.internal || date;
+        const [ [ events ] ] = await pool.query('CALL GetEventsToDisplay_V2(?)', [ dateToDB ]);
         for (const event of events) {
             event.start_date = formatDateTime(event.start_date);
             event.tag_ids = isNotNil(event.tag_ids) ? map((id) => Number(id))(split(',', event.tag_ids)): [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.744.0",
+        "@date-fns/tz": "^1.3.1",
         "aws-sdk": "^2.1692.0",
         "date-fns": "^4.1.0",
         "dotenv": "^16.4.7",
@@ -955,6 +956,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.3.1.tgz",
+      "integrity": "sha512-LnBOyuj+piItX/D5BWBSckBsuZyOt7Jg2obGNiObq7qjl1A2/8F+i4RS8/MmkSdnw6hOe6afrJLCWrUWZw5Mlw=="
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.744.0",
+    "@date-fns/tz": "^1.3.1",
     "aws-sdk": "^2.1692.0",
     "date-fns": "^4.1.0",
     "dotenv": "^16.4.7",

--- a/server.js
+++ b/server.js
@@ -18,10 +18,11 @@ import {
   groupEventsByDayPlusDate,
   createCalendar,
 } from './utilities/dates.js';
+import { TZDate } from "@date-fns/tz";
 import { filterEventsbyTags } from './utilities/filtering.js';
 import { constructImageUrl } from './utilities/local-url.js';
 import { requireAuth } from './utilities/authentication.js';
-import { find, propEq, prop, map, includes, isNotEmpty } from 'ramda';
+import { find, propEq, prop, map, includes } from 'ramda';
 dotenv.config();
 
 let app = express();
@@ -172,12 +173,14 @@ app.post("/upload", upload.single("image"), async (req, res) => {
 });
 
 app.get("/", async (req, res) => {
+  // const date = TZDate.tz("America/New_York");
   const date = new Date();
   const eventsToDisplay = await executeGetEventsToDisplay(date);
   const calendar = createCalendar(date);
   const populatedCalendar = groupEventsByDayPlusDate(calendar)(eventsToDisplay);
   const tagList = await executeGetTags()
   tagList.forEach((t) => t.checked = true)
+  console.log(TZDate.tz("America/New_York"));
 
   res.render('weekly.ejs', { events: populatedCalendar, tags: tagList });
 });

--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ import {
   groupEventsByDayPlusDate,
   createCalendar,
 } from './utilities/dates.js';
+import { TIMEZONE } from './utilities/constants.js';
 import { TZDate } from "@date-fns/tz";
 import { filterEventsbyTags } from './utilities/filtering.js';
 import { constructImageUrl } from './utilities/local-url.js';
@@ -173,14 +174,12 @@ app.post("/upload", upload.single("image"), async (req, res) => {
 });
 
 app.get("/", async (req, res) => {
-  // const date = TZDate.tz("America/New_York");
-  const date = new Date();
+  const date = TZDate.tz(TIMEZONE);
   const eventsToDisplay = await executeGetEventsToDisplay(date);
   const calendar = createCalendar(date);
   const populatedCalendar = groupEventsByDayPlusDate(calendar)(eventsToDisplay);
-  const tagList = await executeGetTags()
-  tagList.forEach((t) => t.checked = true)
-  console.log(TZDate.tz("America/New_York"));
+  const tagList = await executeGetTags();
+  tagList.forEach((t) => t.checked = true);
 
   res.render('weekly.ejs', { events: populatedCalendar, tags: tagList });
 });
@@ -200,7 +199,7 @@ app.get('/filtered-weekly', async (req, res) => {
       }
     })
   })
-  const date = new Date();
+  const date = TZDate.tz(TIMEZONE);
   const eventsToDisplay = await executeGetEventsToDisplay(date);
   const calendar = createCalendar(date);
   const populatedCalendar = groupEventsByDayPlusDate(calendar)(filterEventsbyTags(filteringTagIds)(eventsToDisplay));

--- a/test/db-tests.js
+++ b/test/db-tests.js
@@ -156,7 +156,7 @@ t.test('Get Events to Display', async (t) => {
   }
 
   // Test retrieval
-  const displayEvents = await executeGetEventsToDisplay(testDates.exactDate.internal);
+  const displayEvents = await executeGetEventsToDisplay(testDates.exactDate);
   console.log('Display Events:', displayEvents);
   const retrievedIds = map(event => event.id, displayEvents);
 

--- a/test/db-tests.js
+++ b/test/db-tests.js
@@ -21,6 +21,8 @@ import {
   intersection,
 } from 'ramda';
 import { filterEventsbyTags } from '../utilities/filtering.js';
+import { TZDate } from "@date-fns/tz";
+import { TIMEZONE } from '../utilities/constants.js';
 
 delete process.env.DB_HOST;
 delete process.env.DB_USER;
@@ -92,7 +94,7 @@ const testEventTemplate = {
 };
 
 t.test('Write Event', async (t) => {
-  const testEvent = { ...testEventTemplate };
+  const testEvent = { ...testEventTemplate, dates: [testEventTemplate.startDate] };
   
   const result = await executeWriteEvent(testEvent);
   t.ok(result.insertId, 'Should return an insert ID');
@@ -104,7 +106,7 @@ t.test('Write Event', async (t) => {
 
 t.test('Get Event Details', async (t) => {
   // Create test event
-  const testEvent = { ...testEventTemplate };
+  const testEvent = { ...testEventTemplate, dates: [testEventTemplate.startDate] };
   const writeResult = await executeWriteEvent(testEvent);
   const eventId = writeResult.insertId;
 
@@ -123,7 +125,7 @@ t.test('Get Event Details', async (t) => {
 });
 
 t.test('Get Events to Display', async (t) => {
-  const baseDate = '2024-02-01T00:00:00';
+  const baseDate = TZDate.tz(TIMEZONE);
   const testDates = {
     fiveDaysBefore: format(addDays(baseDate, -5), 'yyyy-MM-dd'),
     OneDayBefore: format(addDays(baseDate, -1), 'yyyy-MM-dd'),
@@ -137,14 +139,14 @@ t.test('Get Events to Display', async (t) => {
 
   // Create test events
   const eventsToCreate = [
-    { ...testEventTemplate, startDate: testDates.fiveDaysBefore },
-    { ...testEventTemplate, startDate: testDates.OneDayBefore },
-    { ...testEventTemplate, startDate: testDates.exactDate },
-    { ...testEventTemplate, startDate: testDates.fiveDaysAfter },
-    { ...testEventTemplate, startDate: testDates.tenDaysAfter },
-    { ...testEventTemplate, startDate: testDates.elevenDaysAfter },
-    { ...testEventTemplate, startDate: testDates.thirtyOneDaysAfter },
-    { ...testEventTemplate, startDate: testDates.fourtyDaysAfter },
+    { ...testEventTemplate, startDate: testDates.fiveDaysBefore, dates: [testDates.fiveDaysBefore] },
+    { ...testEventTemplate, startDate: testDates.OneDayBefore, dates: [testDates.OneDayBefore] },
+    { ...testEventTemplate, startDate: testDates.exactDate, dates: [testDates.exactDate] },
+    { ...testEventTemplate, startDate: testDates.fiveDaysAfter, dates: [testDates.fiveDaysAfter] },
+    { ...testEventTemplate, startDate: testDates.tenDaysAfter, dates: [testDates.tenDaysAfter] },
+    { ...testEventTemplate, startDate: testDates.elevenDaysAfter, dates: [testDates.elevenDaysAfter] },
+    { ...testEventTemplate, startDate: testDates.thirtyOneDaysAfter, dates: [testDates.thirtyOneDaysAfter] },
+    { ...testEventTemplate, startDate: testDates.fourtyDaysAfter, dates: [testDates.fourtyDaysAfter] },
   ];
 
   const createdIds = [];
@@ -154,7 +156,7 @@ t.test('Get Events to Display', async (t) => {
   }
 
   // Test retrieval
-  const displayEvents = await executeGetEventsToDisplay(new Date(testDates.exactDate));
+  const displayEvents = await executeGetEventsToDisplay(testDates.exactDate.internal);
   console.log('Display Events:', displayEvents);
   const retrievedIds = map(event => event.id, displayEvents);
 
@@ -172,7 +174,7 @@ t.test('Get Events to Display', async (t) => {
 // test to approve events
 t.test('Approve Events', async (t) => {
   // Create test event
-  const testEvent = { ...testEventTemplate, approved: 0 };
+  const testEvent = { ...testEventTemplate, dates: [testEventTemplate.startDate], approved: 0 };
   const writeResult = await executeWriteEvent(testEvent);
   const eventId = writeResult.insertId;
 
@@ -188,11 +190,11 @@ t.test('Approve Events', async (t) => {
 // test to filter events by tag IDs
 t.test('Filter Events by Tag IDs', async (t) => {
   // Create test events
-  const testEvent1 = { ...testEventTemplate, tagIDs: [1, 2] };
-  const testEvent2 = { ...testEventTemplate, tagIDs: [2, 3] };
-  const testEvent3 = { ...testEventTemplate, tagIDs: [3, 4] };
-  const testEvent4 = { ...testEventTemplate, tagIDs: [4, 5] };
-  const testEvent5 = { ...testEventTemplate, tagIDs: [5, 6] };
+  const testEvent1 = { ...testEventTemplate, dates: [testEventTemplate.startDate], tagIDs: [1, 2] };
+  const testEvent2 = { ...testEventTemplate, dates: [testEventTemplate.startDate], tagIDs: [2, 3] };
+  const testEvent3 = { ...testEventTemplate, dates: [testEventTemplate.startDate], tagIDs: [3, 4] };
+  const testEvent4 = { ...testEventTemplate, dates: [testEventTemplate.startDate], tagIDs: [4, 5] };
+  const testEvent5 = { ...testEventTemplate, dates: [testEventTemplate.startDate], tagIDs: [5, 6] };
 
   const eventsToCreate = [testEvent1, testEvent2, testEvent3, testEvent4, testEvent5];
   const createdIds = [];

--- a/utilities/constants.js
+++ b/utilities/constants.js
@@ -1,0 +1,1 @@
+export const TIMEZONE = 'America/New_York';


### PR DESCRIPTION
Instead of relying on the system timezone, which may vary from the desired timezone, the application now explicitly gets zoned date-time using [@date-fns/tz](https://github.com/date-fns/tz)

